### PR TITLE
Flatten `value` context so that templates can be used outside of blocks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ INSTALL_REQUIRES = [
 ]
 
 TESTING_REQUIRES = [
-
+    'beautifulsoup4==4.7.1'
 ]
 
 

--- a/tests/test_action_block.py
+++ b/tests/test_action_block.py
@@ -1,0 +1,14 @@
+from bs4 import BeautifulSoup
+from django.test import Client
+import pytest
+
+
+@pytest.mark.django_db
+def test_action_block(db, django_db_setup, client: Client):
+    response = client.get('/')
+    soup = BeautifulSoup(response.content, 'html.parser')
+    a_tag = soup.select_one('a.nhsuk-action-link__link')
+    span_tag = a_tag.select_one('span.nhsuk-action-link__text')
+
+    assert a_tag['href'] == 'https://example.com'
+    assert span_tag.text == 'Action Link'

--- a/wagtailnhsukfrontend/blocks.py
+++ b/wagtailnhsukfrontend/blocks.py
@@ -11,7 +11,16 @@ from wagtail.core.blocks import (
 from wagtail.images.blocks import ImageChooserBlock
 
 
-class ActionLinkBlock(StructBlock):
+class FlattenValueContext:
+    """NHS.UK StructBlock mixin that flattens `value` for re-usability of templates"""
+
+    def get_context(self, value, parent_context=None):
+        context = super().get_context(value, parent_context)
+        context.update(value)
+        return context
+
+
+class ActionLinkBlock(FlattenValueContext, StructBlock):
 
     text = CharBlock(label="Link text", required=True)
     external_url = URLBlock(label="URL", required=True)
@@ -21,7 +30,7 @@ class ActionLinkBlock(StructBlock):
         template = 'wagtailnhsukfrontend/action_link.html'
 
 
-class CareCardBlock(StructBlock):
+class CareCardBlock(FlattenValueContext, StructBlock):
 
     type = ChoiceBlock([
         ('primary', 'Non-urgent'),
@@ -45,7 +54,7 @@ class CareCardBlock(StructBlock):
         template = 'wagtailnhsukfrontend/care_card.html'
 
 
-class WarningCalloutBlock(StructBlock):
+class WarningCalloutBlock(FlattenValueContext, StructBlock):
 
     title = CharBlock(required=True, default='Important')
     heading_level = IntegerBlock(required=True, min_value=2, max_value=4, default=3, help_text='The heading level affects users with screen readers. Default=3, Min=2, Max=4.')
@@ -55,7 +64,7 @@ class WarningCalloutBlock(StructBlock):
         template = 'wagtailnhsukfrontend/warning_callout.html'
 
 
-class InsetTextBlock(StructBlock):
+class InsetTextBlock(FlattenValueContext, StructBlock):
 
     body = RichTextBlock(required=True)
 
@@ -63,7 +72,7 @@ class InsetTextBlock(StructBlock):
         template = 'wagtailnhsukfrontend/inset_text.html'
 
 
-class DetailsBlock(StructBlock):
+class DetailsBlock(FlattenValueContext, StructBlock):
 
     title = CharBlock(required=True)
     body = RichTextBlock(required=True)
@@ -78,7 +87,7 @@ class ExpanderBlock(DetailsBlock):
         template = 'wagtailnhsukfrontend/expander.html'
 
 
-class ExpanderGroupBlock(StructBlock):
+class ExpanderGroupBlock(FlattenValueContext, StructBlock):
 
     expanders = ListBlock(ExpanderBlock)
 
@@ -86,7 +95,7 @@ class ExpanderGroupBlock(StructBlock):
         template = 'wagtailnhsukfrontend/expander_group.html'
 
 
-class PanelBlock(StructBlock):
+class PanelBlock(FlattenValueContext, StructBlock):
 
     label = CharBlock(required=False)
     heading_level = IntegerBlock(min_value=2, max_value=4, default=3, help_text='The heading level affects users with screen readers. Ignore this if there is no label. Default=3, Min=2, Max=4.')
@@ -96,7 +105,7 @@ class PanelBlock(StructBlock):
         template = 'wagtailnhsukfrontend/panel.html'
 
 
-class GreyPanelBlock(StructBlock):
+class GreyPanelBlock(FlattenValueContext, StructBlock):
 
     label = CharBlock(label='heading', required=False)
     heading_level = IntegerBlock(min_value=2, max_value=4, default=3, help_text='The heading level affects users with screen readers. Ignore this if there is no heading. Default=3, Min=2, Max=4.')
@@ -106,7 +115,7 @@ class GreyPanelBlock(StructBlock):
         template = 'wagtailnhsukfrontend/grey_panel.html'
 
 
-class PanelListBlock(StructBlock):
+class PanelListBlock(FlattenValueContext, StructBlock):
 
     panels = ListBlock(StructBlock([
         ('left_panel', PanelBlock()),
@@ -117,7 +126,7 @@ class PanelListBlock(StructBlock):
         template = 'wagtailnhsukfrontend/panel_list.html'
 
 
-class DoBlock(StructBlock):
+class DoBlock(FlattenValueContext, StructBlock):
 
     heading_level = IntegerBlock(required=True, min_value=2, max_value=4, default=3, help_text='The heading level affects users with screen readers. Default=3, Min=2, Max=4.')
 
@@ -127,7 +136,7 @@ class DoBlock(StructBlock):
         template = 'wagtailnhsukfrontend/do_list.html'
 
 
-class DontBlock(StructBlock):
+class DontBlock(FlattenValueContext, StructBlock):
 
     heading_level = IntegerBlock(required=True, min_value=2, max_value=4, default=3, help_text='The heading level affects users with screen readers. Default=3, Min=2, Max=4.')
 
@@ -137,7 +146,7 @@ class DontBlock(StructBlock):
         template = 'wagtailnhsukfrontend/dont_list.html'
 
 
-class ImageBlock(StructBlock):
+class ImageBlock(FlattenValueContext, StructBlock):
 
     content_image = ImageChooserBlock(required=True)
     alt_text = CharBlock(required=False, help_text="Only leave this blank if the image is decorative.")

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/action_link.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/action_link.html
@@ -1,9 +1,9 @@
 <div class="nhsuk-action-link">
-  <a class="nhsuk-action-link__link" href="{{ value.external_url }}" {% if value.new_window %}target="_blank" {% endif %}>
+  <a class="nhsuk-action-link__link" href="{{ external_url }}" {% if new_window %}target="_blank" {% endif %}>
     <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M0 0h24v24H0z" fill="none"></path>
       <path d="M12 2a10 10 0 0 0-9.95 9h11.64L9.74 7.05a1 1 0 0 1 1.41-1.41l5.66 5.65a1 1 0 0 1 0 1.42l-5.66 5.65a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41L13.69 13H2.05A10 10 0 1 0 12 2z"></path>
     </svg>
-    <span class="nhsuk-action-link__text">{{ value.text }}</span>
+    <span class="nhsuk-action-link__text">{{ text }}</span>
   </a>
 </div>

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/care_card.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/care_card.html
@@ -1,13 +1,13 @@
-<div class="nhsuk-care-card nhsuk-care-card--{{ value.type }}">
+<div class="nhsuk-care-card nhsuk-care-card--{{ type }}">
   <div class="nhsuk-care-card__heading-container">
-    <h{{ value.heading_level }} class="nhsuk-care-card__heading">
+    <h{{ heading_level }} class="nhsuk-care-card__heading">
       <span role="text">
-        <span class="nhsuk-u-visually-hidden">{{ accessible_title_prefix }} </span>{{ value.title }}
+        <span class="nhsuk-u-visually-hidden">{{ accessible_title_prefix }} </span>{{ title }}
       </span>
-    </h{{ value.heading_level }}>
+    </h{{ heading_level }}>
     <span class="nhsuk-care-card__arrow" aria-hidden="true"></span>
   </div>
   <div class="nhsuk-care-card__content">
-    {{ value.body }}
+    {{ body }}
   </div>
 </div>

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/details.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/details.html
@@ -1,10 +1,10 @@
 <details class="nhsuk-details{% if expander %} nhsuk-expander{% endif %}">
   <summary class="nhsuk-details__summary">
     <span class="nhsuk-details__summary-text">
-    {{value.title}}
+    {{ title }}
     </span>
   </summary>
   <div class="nhsuk-details__text">
-    {{value.body}}
+    {{ body }}
   </div>
 </details>

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/do_list.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/do_list.html
@@ -1,7 +1,7 @@
 <div class="nhsuk-do-dont-list">
-  <h{{ value.heading_level }} class="nhsuk-do-dont-list__label">Do</h{{ value.heading_level }} >
+  <h{{ heading_level }} class="nhsuk-do-dont-list__label">Do</h{{ heading_level }} >
   <ul class="nhsuk-list nhsuk-list--tick">
-    {% for body in value.do %}
+    {% for body in do %}
     <li>
       <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" aria-hidden="true">
         <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/dont_list.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/dont_list.html
@@ -1,7 +1,7 @@
 <div class="nhsuk-do-dont-list">
-  <h{{ value.heading_level }} class="nhsuk-do-dont-list__label">Don&#39;t</h{{ value.heading_level }}>
+  <h{{ heading_level }} class="nhsuk-do-dont-list__label">Don&#39;t</h{{ heading_level }}>
   <ul class="nhsuk-list nhsuk-list--cross">
-    {% for body in value.dont %}
+    {% for body in dont %}
     <li>
       <svg class="nhsuk-icon nhsuk-icon__cross" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
         <path d="M17 18.5c-.4 0-.8-.1-1.1-.4l-10-10c-.6-.6-.6-1.6 0-2.1.6-.6 1.5-.6 2.1 0l10 10c.6.6.6 1.5 0 2.1-.3.3-.6.4-1 .4z"></path>

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/expander_group.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/expander_group.html
@@ -1,8 +1,8 @@
 {% load wagtailcore_tags %}
 <div class="nhsuk-expander-group">
 
-  {% for expander in value.expanders %}
+  {% for expander in expanders %}
     {% include_block expander %}
   {% endfor %}
-  
+
 </div>

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/image.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/image.html
@@ -1,12 +1,12 @@
 {% load wagtailimages_tags %}
 
-{% image value.content_image width-320 as one_image %}
-{% image value.content_image width-510 as two_image %}
-{% image value.content_image width-640 as three_image %}
-{% image value.content_image width-767 as four_image %}
-{% image value.content_image width-1019 as five_image %}
-{% image value.content_image width-1125 as six_image %}
-{% image value.content_image width-1534 as seven_image %}
+{% image content_image width-320 as one_image %}
+{% image content_image width-510 as two_image %}
+{% image content_image width-640 as three_image %}
+{% image content_image width-767 as four_image %}
+{% image content_image width-1019 as five_image %}
+{% image content_image width-1125 as six_image %}
+{% image content_image width-1534 as seven_image %}
 
 <figure class="nhsuk-image">
   <img
@@ -19,25 +19,25 @@
     "
     srcset="
 
-      {{one_image.url}} 320w,
+      {{ one_image.url }} 320w,
 
-      {{two_image.url}} 510w,
+      {{ two_image.url }} 510w,
 
-      {{three_image.url}} 640w,
+      {{ three_image.url }} 640w,
 
-      {{four_image.url}} 767w,
+      {{ four_image.url }} 767w,
 
-      {{five_image.url}} 1019w,
+      {{ five_image.url }} 1019w,
 
-      {{six_image.url}} 1125w,
+      {{ six_image.url }} 1125w,
 
-      {{seven_image.url}} 1534w,
+      {{ seven_image.url }} 1534w,
     "
-    alt="{{value.alt_text}}"
+    alt="{{ alt_text }}"
   />
-  {% if value.caption %}
+  {% if caption %}
   <figcaption class="nhsuk-image__caption">
-    {{ value.caption }}
+    {{ caption }}
   </figcaption>
   {% endif %}
 </figure>

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/inset_text.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/inset_text.html
@@ -1,4 +1,4 @@
 <div class="nhsuk-inset-text">
   <span class="nhsuk-u-visually-hidden">Information: </span>
-  {{ value.body }}
+  {{ body }}
 </div>

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/panel.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/panel.html
@@ -1,4 +1,4 @@
-<div class="nhsuk-panel{% if value.label and not grey %}-with-label{% endif %}{% if grey %} nhsuk-panel--grey {% endif %}">
-  {% if value.label %} <h{{ value.heading_level }} {% if value.label and not grey %} class="nhsuk-panel-with-label__label">{% endif %}{%if grey %}>{% endif %}{{ value.label }}</h{{ value.heading_level }}> {% endif %}
-  {{ value.body }}
+<div class="nhsuk-panel{% if label and not grey %}-with-label{% endif %}{% if grey %} nhsuk-panel--grey {% endif %}">
+  {% if label %} <h{{ heading_level }} {% if label and not grey %} class="nhsuk-panel-with-label__label">{% endif %}{%if grey %}>{% endif %}{{ label }}</h{{ heading_level }}> {% endif %}
+  {{ body }}
 </div>

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/panel_list.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/panel_list.html
@@ -1,4 +1,4 @@
-{% for panel in value.panels %}
+{% for panel in panels %}
   <div class="nhsuk-grid-row nhsuk-panel-group">
     <div class="nhsuk-grid-column-one-half nhsuk-panel-group__item">
       <div class="nhsuk-panel">
@@ -12,7 +12,7 @@
       <div class="nhsuk-panel">
         {% if panel.right_panel.label %}
           <h{{ panel.right_panel.heading_level }}>{{ panel.right_panel.label }}</h{{ panel.right_panel.heading_level }}>
-        {% endif %}  
+        {% endif %}
         {{ panel.right_panel.body }}
       </div>
     </div>

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/skip_link.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/skip_link.html
@@ -1,1 +1,1 @@
-<a class="nhsuk-skip-link" href="{{href|default:"#maincontent" }}">{{ text|default:"Skip to main content"}}</a>
+<a class="nhsuk-skip-link" href="{{ href|default:"#maincontent" }}">{{ text|default:"Skip to main content"}}</a>

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/warning_callout.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/warning_callout.html
@@ -1,4 +1,4 @@
 <div class="nhsuk-warning-callout">
-  <h{{ value.heading_level }} class="nhsuk-warning-callout__label">{{ value.title }}</h{{ value.heading_level }}>
-  {{ value.body }}
+  <h{{ heading_level }} class="nhsuk-warning-callout__label">{{ title }}</h{{ heading_level }}>
+  {{ body }}
 </div>


### PR DESCRIPTION
This is @wengole's change. I've just rebased it onto dev and added the extra components that are in the dev branch.

resolves #38 