### PR TITLE
Update outdated service manual URLs

### DIFF
--- a/docs/components/action_link.md
+++ b/docs/components/action_link.md
@@ -16,5 +16,5 @@ class MyPage(Page):
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/action-link)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/action-link)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/action-link)

--- a/docs/components/back_link.md
+++ b/docs/components/back_link.md
@@ -11,5 +11,5 @@
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/back-link)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/back-link)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/back-link)

--- a/docs/components/breadcrumb.md
+++ b/docs/components/breadcrumb.md
@@ -24,5 +24,5 @@ tag.
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/back-link)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/back-link)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/back-link)

--- a/docs/components/care_card.md
+++ b/docs/components/care_card.md
@@ -47,5 +47,5 @@ class MyPage(Page):
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/care-cards)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/care-cards)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/care-card)

--- a/docs/components/contents_list.md
+++ b/docs/components/contents_list.md
@@ -35,5 +35,5 @@ An array of links should be passed as a template variable
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/contents-list)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/contents-list)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/contents-list)

--- a/docs/components/details.md
+++ b/docs/components/details.md
@@ -47,5 +47,5 @@ class MyPage(Page):
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/details)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/details)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/details)

--- a/docs/components/do.md
+++ b/docs/components/do.md
@@ -16,6 +16,6 @@ class MyPage(Page):
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/do-and-dont-list)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/do-and-dont-lists)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/do-dont-list)
 

--- a/docs/components/dont.md
+++ b/docs/components/dont.md
@@ -15,6 +15,6 @@ class MyPage(Page):
 ```
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/do-and-dont-list)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/do-and-dont-lists)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/do-dont-list)
 

--- a/docs/components/expander.md
+++ b/docs/components/expander.md
@@ -65,5 +65,5 @@ class MyPage(Page):
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/expander)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/expander)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/details)

--- a/docs/components/header.md
+++ b/docs/components/header.md
@@ -114,5 +114,5 @@ def navigation(request):
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/header)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/header)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/header)

--- a/docs/components/image.md
+++ b/docs/components/image.md
@@ -18,5 +18,5 @@ class HomePage(Page):
 ```
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/images)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/images)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/images)

--- a/docs/components/inset_text.md
+++ b/docs/components/inset_text.md
@@ -16,5 +16,5 @@ class MyPage(Page):
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/inset-text)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/inset-text)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/inset-text)

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -38,6 +38,6 @@ If `prev_url` and `next_url` are unspecified, the relevant link will not be show
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/pagination)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/pagination)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/pagination)
 

--- a/docs/components/review_date.md
+++ b/docs/components/review_date.md
@@ -23,5 +23,5 @@ To include the review date component on a page you will have to include the revi
 
 # Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/review-date)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/review-date)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/review-date)

--- a/docs/components/skip_link.md
+++ b/docs/components/skip_link.md
@@ -17,6 +17,6 @@ To ensure that the skip link works as intended make sure its the first include i
 ```
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/skip-link)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/skip-link)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/skip-link)
 

--- a/docs/components/summary_list.md
+++ b/docs/components/summary_list.md
@@ -16,6 +16,6 @@ class MyPage(Page):
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/summary-list)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/summary-list)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/summary-list)
 

--- a/docs/components/warning_callout.md
+++ b/docs/components/warning_callout.md
@@ -16,5 +16,5 @@ class MyPage(Page):
 
 ## Reference
 
-* [Service Manual](https://beta.nhs.uk/service-manual/styles-components-patterns/warning-callout)
+* [Service Manual](https://service-manual.nhs.uk/design-system/components/warning-callout)
 * [Frontend Library](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/warning-callout)


### PR DESCRIPTION
Corrected out of date links https://beta.nhs.uk/service-manual → https://service-manual.nhs.uk/design-system/components/

All links now work correctly.