### PR TITLE
Amend aria attributes on header menu toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # CHANGELOG
 
+## v1.2.1
+- Remove static `aria-label="Open menu"` on header menu toggle. Add descriptive `aria-expanded="false"` to toggle on inital page load.
 
 ## v1.2.0
-- - Use the latest version of the NHS.UK frontend library ([v5.2.0](https://github.com/nhsuk/nhsuk-frontend/blob/master/CHANGELOG.md#520---22-september-2021))
+- Use the latest version of the NHS.UK frontend library ([v5.2.0](https://github.com/nhsuk/nhsuk-frontend/blob/master/CHANGELOG.md#520---22-september-2021))
 
 ## v1.1.0
 - Add optional default heading level setting for care cards

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/header/menu_toggle.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/header/menu_toggle.html
@@ -1,3 +1,3 @@
 <div class="nhsuk-header__menu">
-  <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
+  <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-expanded="false">Menu</button>
 </div>


### PR DESCRIPTION
The nomensa audit has highlighted that the `aria-label="Open menu"` is different to the visual label `Menu` and also doesn't make sense if the Menu is actually in an expanded state.

Removing the static label that and replacing with `aria-expanded="false"` will make things clearer for users of assistive technology.