### PR TITLE
Include forms templates when building python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include wagtailnhsukfrontend/static/* *
 recursive-include wagtailnhsukfrontend/templates/* *
+recursive-include wagtailnhsukfrontend/forms/templates/* *


### PR DESCRIPTION
The form templates are not being built into the package. Trying to use forms as documented will result in a `TemplateDoesNotExist` error.