### PR TITLE
Action links have wrong styling when in an emergency care card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # CHANGELOG
 
+## 2.1.0
+Wagtail 7.1 maintenance
+- Add tox testing for Wagtail 7.1
+- Drop tox testing for Wagtail 6.4
+- Remove support for Wagtail versions < 6.3 due to EOL
+
+Wagtail 7.0 maintenance
+
+- Add tox testing for Wagtail 7.0 and Django 5.2
+- Drop tox testing for Wagtail 6.0,6.1,6.2 and Django 5.0
+
+Wagtail 6.3 maintenance
+
+- Add tox testing for Wagtail 6.3, 6.4
+- Add tox testing for Django 5.1
+- Add tox testing for Python 3.13
+- Drop python 3.8 testing
+
+Bugfixes
+
+- Fix action links having the wrong styling when in an emergency care card.
+
 ## 2.0.0
 - Use the latest version of the NHS.UK frontend library ([v10.3.1](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v10.3.1)) (breaking changes)
 
@@ -22,25 +44,6 @@
   
 - Updated package docs and examples to use the new versioned frontend assets.
 
-## Unreleased
-
-Wagtail 7.1 maintenanc
-- Add tox resting for Wagtail 7.1
-- Drop tox testing for Wagtail 6.4
-- Remove support for Wagtail versions < 6.3 due to EOL
-
-
-Wagtail 7.0 maintenance
-
-- Add tox testing for Wagtail 7.0 and Django 5.2
-- Drop tox testing for Wagtail 6.0,6.1,6.2 and Django 5.0
-
-Wagtail 6.3 maintenance
-
-- Add tox testing for Wagtail 6.3, 6.4
-- Add tox testing for Django 5.1
-- Add tox testing for Python 3.13
-- Drop python 3.8 testing
 
 ## 1.6.0
 

--- a/tests/test_action_block.py
+++ b/tests/test_action_block.py
@@ -2,7 +2,8 @@ from bs4 import BeautifulSoup
 from django.core.exceptions import ValidationError
 from django.test import Client
 import pytest
-from wagtailnhsukfrontend.blocks import ActionLinkBlock
+from wagtail.models import Page
+from wagtailnhsukfrontend.blocks import ActionLinkBlock, CareCardBlock
 
 
 @pytest.mark.django_db
@@ -74,3 +75,94 @@ def test_action_block_clean_two_links():
     assert error_message in excinfo.value.params["internal_page"]
     assert error_message in excinfo.value.params["external_url"]
     assert excinfo.value.message == "Validation error in ActionLinkBlock"
+
+
+@pytest.mark.django_db
+def test_action_link_reversed_in_emergency_care_card():
+    block = CareCardBlock()
+
+    value = block.to_python({
+        "type": "immediate",
+        "heading_level": 3,
+        "title": "Immediate!",
+        "body": [
+            {
+                "type": "action_link",
+                "value": {
+                    "text": "Emergency action",
+                    "external_url": "https://example.com/",
+                    "new_window": False,
+                    "internal_page": None,
+                },
+            }
+        ],
+    })
+
+    cleaned = block.clean(value)
+
+    html = block.render(cleaned)
+
+    assert 'class="nhsuk-action-link nhsuk-action-link--reverse"' in html
+
+
+@pytest.mark.django_db
+def test_action_link_not_reversed_in_primary_care_card():
+    block = CareCardBlock()
+
+    value = block.to_python({
+        "type": "primary",
+        "heading_level": 3,
+        "title": "Non-urgent",
+        "body": [
+            {
+                "type": "action_link",
+                "value": {
+                    "text": "Standard action",
+                    "external_url": "https://example.com/",
+                    "new_window": False,
+                    "internal_page": None,
+                },
+            }
+        ],
+    })
+
+    cleaned = block.clean(value)
+
+    html = block.render(cleaned)
+
+    assert 'class="nhsuk-action-link"' in html
+    assert 'nhsuk-action-link--reverse' not in html
+
+
+@pytest.mark.django_db
+def test_action_link_internal_page_reversed_in_emergency_care_card():
+    home = Page.objects.get(id=1)
+    internal_page = home.add_child(
+        instance=Page(title="Care card target", slug="care-card-target")
+    )
+
+    block = CareCardBlock()
+
+    value = block.to_python({
+        "type": "immediate",
+        "heading_level": 3,
+        "title": "Immediate!",
+        "body": [
+            {
+                "type": "action_link",
+                "value": {
+                    "text": "Emergency internal action",
+                    "external_url": None,
+                    "new_window": False,
+                    "internal_page": internal_page.id,
+                },
+            }
+        ],
+    })
+
+    cleaned = block.clean(value)
+
+    html = block.render(cleaned)
+
+    assert f'href="{internal_page.url}"' in html
+    assert 'class="nhsuk-action-link nhsuk-action-link--reverse"' in html

--- a/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/action_link.html
+++ b/wagtailnhsukfrontend/templates/wagtailnhsukfrontend/action_link.html
@@ -1,9 +1,9 @@
 {% load nhsukfrontend_extra_parameters_tags %}
 
 {% if internal_page %}
-<a class="nhsuk-action-link" href="{{ internal_page.url }}">
+<a class="nhsuk-action-link{% if care_card_type == 'emergency' %} nhsuk-action-link--reverse{% endif %}" href="{{ internal_page.url }}">
 {% else %}
-<a class="nhsuk-action-link" href="{{ external_url }}" {% if new_window %}target="_blank" {% endif %}>
+<a class="nhsuk-action-link{% if care_card_type == 'emergency' %} nhsuk-action-link--reverse{% endif %}" href="{{ external_url }}" {% if new_window %}target="_blank" rel="noopener noreferrer" {% endif %}>
 {% endif %}
   <svg class="nhsuk-icon nhsuk-icon--arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
     <path d="M12 2a10 10 0 0 0-10 9h11.7l-4-4a1 1 0 0 1 1.5-1.4l5.6 5.7a1 1 0 0 1 0 1.4l-5.6 5.7a1 1 0 0 1-1.5 0 1 1 0 0 1 0-1.4l4-4H2A10 10 0 1 0 12 2z"/>


### PR DESCRIPTION
Update action links to have the correct styling when inside an emergency care card.

- Add conditional nhsuk-action-link--reverse styling in the action-link template when rendered inside an emergency care card.
- Add tests covering reversed styling for emergency care cards and non-reversed styling for primary care cards.
- Promote unreleased changelog entries into 2.1.0 and note the styling fix.

